### PR TITLE
コメントの表示位置修正

### DIFF
--- a/CommentStyle.css
+++ b/CommentStyle.css
@@ -248,7 +248,7 @@ yt-live-chat-text-message-renderer.style-scope.yt-live-chat-item-list-renderer {
 }
 
 yt-live-chat-text-message-renderer.style-scope.yt-live-chat-item-list-renderer {
-    background: rgba(0, 0, 0, .5);
+    background: rgba(0, 0, 0, .6);
     border-radius: 12px;
     margin: .25rem;
     float: left;

--- a/CommentStyle.css
+++ b/CommentStyle.css
@@ -38,6 +38,11 @@ yt-live-chat-legacy-paid-message-renderer #content {
     overflow: initial !important;
 }
 
+/* コメントを下から表示 */
+#item-offset {
+    height: 100vh !important;
+}
+
 /* スクロールバーを隠す設定 */
 yt-live-chat-item-list-renderer #items {
     overflow: hidden !important;
@@ -46,9 +51,10 @@ yt-live-chat-item-list-renderer #item-scroller{
     overflow: hidden !important;
 }
 
-/* ヘッダとコメント入力欄を隠す設定 */
+/* ヘッダとコメント入力欄とガイドラインを隠す設定 */
 yt-live-chat-header-renderer,
-yt-live-chat-message-input-renderer {
+yt-live-chat-message-input-renderer,
+yt-live-chat-viewer-engagement-message-renderer {
     display: none !important;
 }
 


### PR DESCRIPTION
## 概要
配信初期のコメント位置が上辺基準での表示になっている。
下から追加される形式なので、初めのコメントから下に表示されていて欲しい。

## 修正点
コメント欄の高さを画面100%にすることでコメントを下に配置。
ガイドラインの表示があるため、その要素を非表示。
また、某配信プラットフォーム本家に合わせたコメント背景色の設定。

修正前
![変更前](https://user-images.githubusercontent.com/23465174/134036236-8afe92e3-e56c-4d42-b1f2-4195c4517097.png)

修正後
![変更後](https://user-images.githubusercontent.com/23465174/134036268-266a6700-47fa-416f-ac75-0c42f3c0c765.png)
